### PR TITLE
Implement Select

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -393,6 +393,10 @@ func (ac *arrayContainer) rank(x uint16) int {
 	}
 }
 
+func (ac *arrayContainer) selectInt(x uint16) int {
+	return int(ac.content[x])
+}
+
 func (ac *arrayContainer) clone() container {
 	ptr := arrayContainer{make([]uint16, len(ac.content))}
 	copy(ptr.content, ac.content[:])

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -361,6 +361,18 @@ func (bc *bitmapContainer) rank(x uint16) int {
 	}
 }
 
+func (bc *bitmapContainer) selectInt(x uint16) int {
+	remaining := x
+	for k := 0; k < len(bc.bitmap); k++ {
+		w := popcount(bc.bitmap[k])
+		if uint16(w) > remaining {
+			return int(k*64 + selectBitPosition(bc.bitmap[k], int(remaining)))
+		}
+		remaining -= uint16(w)
+	}
+	return -1
+}
+
 func (bc *bitmapContainer) xorBitmap(value2 *bitmapContainer) container {
 	newCardinality := int(popcntXorSlice(bc.bitmap, value2.bitmap))
 

--- a/roaring_test.go
+++ b/roaring_test.go
@@ -1,12 +1,13 @@
 package roaring
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/willf/bitset"
 	"log"
 	"math/rand"
 	"strconv"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/willf/bitset"
 )
 
 func TestRoaringBitmapRank(t *testing.T) {
@@ -20,6 +21,30 @@ func TestRoaringBitmapRank(t *testing.T) {
 				for y := 0; y <= N; y += 1 {
 					if rb1.Rank(y) != (y+1+gap-1)/gap {
 						So(rb1.Rank(y), ShouldEqual, (y+1+gap-1)/gap)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRoaringBitmapSelect(t *testing.T) {
+	for N := 1; N <= 1048576; N *= 2 {
+		Convey("rank tests"+strconv.Itoa(N), t, func() {
+			for gap := 1; gap <= 65536; gap *= 2 {
+				rb1 := NewRoaringBitmap()
+				for x := 0; x <= N; x += gap {
+					rb1.Add(x)
+				}
+				for y := 0; y <= N/gap; y += 1 {
+					expectedInt := y * gap
+					i, err := rb1.Select(y)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if i != expectedInt {
+						So(i, ShouldEqual, expectedInt)
 					}
 				}
 			}

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -24,6 +24,7 @@ type container interface {
 	ior(r container) container
 	lazyIOR(r container) container
 	getSizeInBytes() int
+	selectInt(uint16) int
 	serializedSizeInBytes() int
 	readFrom(io.Reader) (int, error)
 	writeTo(io.Writer) (int, error)
@@ -297,7 +298,6 @@ func (b *roaringArray) readFrom(stream io.Reader) (int, error) {
 	}
 	return offset, nil
 }
-
 
 func (ra *roaringArray) advanceUntil(min uint16, pos int) int {
 	lower := pos + 1

--- a/util.go
+++ b/util.go
@@ -133,7 +133,7 @@ func selectBitPosition(w uint64, j int) int {
 	// Divide 64bit
 	part := w & 0xFFFFFFFF
 	n := popcount(part)
-	if n < uint64(j) {
+	if n <= uint64(j) {
 		part = w >> 32
 		seen += 32
 		j -= int(n)
@@ -143,7 +143,7 @@ func selectBitPosition(w uint64, j int) int {
 	// Divide 32bit
 	part = w & 0xFFFF
 	n = popcount(part)
-	if n < uint64(j) {
+	if n <= uint64(j) {
 		part = w >> 16
 		seen += 16
 		j -= int(n)
@@ -153,7 +153,7 @@ func selectBitPosition(w uint64, j int) int {
 	// Divide 16bit
 	part = w & 0xFF
 	n = popcount(part)
-	if n < uint64(j) {
+	if n <= uint64(j) {
 		part = w >> 8
 		seen += 8
 		j -= int(n)

--- a/util.go
+++ b/util.go
@@ -126,3 +126,47 @@ func maxLowBit() uint16 {
 func toIntUnsigned(x uint16) int {
 	return int(x & 0xFFFF)
 }
+
+func selectBitPosition(w uint64, j int) int {
+	seen := 0
+
+	// Divide 64bit
+	part := w & 0xFFFFFFFF
+	n := popcount(part)
+	if n < uint64(j) {
+		part = w >> 32
+		seen += 32
+		j -= int(n)
+	}
+	w = part
+
+	// Divide 32bit
+	part = w & 0xFFFF
+	n = popcount(part)
+	if n < uint64(j) {
+		part = w >> 16
+		seen += 16
+		j -= int(n)
+	}
+	w = part
+
+	// Divide 16bit
+	part = w & 0xFF
+	n = popcount(part)
+	if n < uint64(j) {
+		part = w >> 8
+		seen += 8
+		j -= int(n)
+	}
+	w = part
+
+	// Lookup in final byte
+	var counter uint
+	for counter = 0; counter < 8; counter++ {
+		j -= int((w >> counter) & 1)
+		if j < 0 {
+			break
+		}
+	}
+	return seen + int(counter)
+}


### PR DESCRIPTION
Roughly follows the same implementation as the Java library.

The method on the containers can't be named `select` because it conflicts with the `select` keyword. I'm happy to change it to something better than `selectInt` but I couldn't come up with anything.

I noticed that the other methods on RoaringBitmap don't return an `error` value. I added one for `Select` since I didn't like the idea of having the method 'silently' fail by returning `-1` if it was given an input it couldn't handle.

I haven't done any benchmarking of `selectBitPosition` but I think it should be reasonably efficient.