### PR TITLE
Make Clone() a deep clone

### DIFF
--- a/roaring_test.go
+++ b/roaring_test.go
@@ -96,6 +96,16 @@ func TestRoaringBitmap(t *testing.T) {
 		}
 	})
 
+	Convey("Test Clone", t, func() {
+		rb1 := NewRoaringBitmap()
+		rb1.Add(10)
+
+		rb2 := rb1.Clone()
+		rb2.Remove(10)
+
+		So(rb1.Contains(10), ShouldBeTrue)
+	})
+
 	Convey("Test ANDNOT", t, func() {
 		rr := NewRoaringBitmap()
 		for k := 4000; k < 4256; k++ {

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -107,7 +107,10 @@ func (ra *roaringArray) clear() {
 func (ra *roaringArray) clone() *roaringArray {
 	sa := new(roaringArray)
 	sa.array = make([]*element, len(ra.array))
-	copy(sa.array, ra.array[:])
+	for i := 0; i < len(ra.array); i++ {
+		newElement := ra.array[i].clone()
+		sa.array[i] = &newElement
+	}
 	return sa
 }
 


### PR DESCRIPTION
The current method is doing a shallow copying of just the references to the elements in the roaring array.

This was causing panics during iteration because the parent bitmap could end up with an invalid structure (element with no values set).