### PR TITLE
Optimize serialization

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -12,12 +12,13 @@ type arrayContainer struct {
 
 // writes the content (omitting the cardinality)
 func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
-	// Write set
-	err := binary.Write(stream, binary.LittleEndian, b.content)
-	if err != nil {
-		return 0, err
+	buf := make([]byte, 2*len(b.content))
+	for i, v := range b.content {
+		base := i * 2
+		buf[base] = byte(v)
+		buf[base+1] = byte(v >> 8)
 	}
-	return 2 * len(b.content), nil
+	return stream.Write(buf)
 }
 
 func (b *arrayContainer) readFrom(stream io.Reader) (int, error) {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,11 +1,13 @@
 package roaring
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/willf/bitset"
 	"math/rand"
+	"runtime"
 	"testing"
-        "runtime"
+
+	"github.com/willf/bitset"
 )
 
 // BENCHMARKS, to run them type "go test -bench Benchmark -run -"
@@ -335,5 +337,59 @@ func BenchmarkSparseIterateBitset(b *testing.B) {
 		for i, e := s.NextSet(0); e; i, e = s.NextSet(i + 1) {
 			c++
 		}
+	}
+}
+
+func BenchmarkSerializationSparse(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 100000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	buf := make([]byte, 0, s.GetSerializedSizeInBytes())
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		w := bytes.NewBuffer(buf[:0])
+		s.WriteTo(w)
+	}
+}
+
+func BenchmarkSerializationMid(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 10000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	buf := make([]byte, 0, s.GetSerializedSizeInBytes())
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		w := bytes.NewBuffer(buf[:0])
+		s.WriteTo(w)
+	}
+}
+
+func BenchmarkSerializationDense(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 150000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	buf := make([]byte, 0, s.GetSerializedSizeInBytes())
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		w := bytes.NewBuffer(buf[:0])
+		s.WriteTo(w)
 	}
 }

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -13,11 +13,19 @@ type bitmapContainer struct {
 // writes the content
 func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
 	// Write set
-	err := binary.Write(stream, binary.LittleEndian, b.bitmap)
-	if err != nil {
-		return 0, err
+	buf := make([]byte, 8*len(b.bitmap))
+	for i, v := range b.bitmap {
+		base := i * 8
+		buf[base] = byte(v)
+		buf[base+1] = byte(v >> 8)
+		buf[base+2] = byte(v >> 16)
+		buf[base+3] = byte(v >> 24)
+		buf[base+4] = byte(v >> 32)
+		buf[base+5] = byte(v >> 40)
+		buf[base+6] = byte(v >> 48)
+		buf[base+7] = byte(v >> 56)
 	}
-	return 8 * len(b.bitmap), nil
+	return stream.Write(buf)
 }
 
 func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
@@ -325,7 +333,6 @@ func (bc *bitmapContainer) orBitmap(value2 *bitmapContainer) container {
 func (bc *bitmapContainer) computeCardinality() {
 	bc.cardinality = int(popcntSlice(bc.bitmap))
 }
-
 
 func (bc *bitmapContainer) iorArray(value2 *arrayContainer) container {
 	answer := bc

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -251,34 +251,30 @@ func (b *roaringArray) serializedSizeInBytes() uint64 {
 }
 
 func (b *roaringArray) writeTo(stream io.Writer) (int, error) {
-	err := binary.Write(stream, binary.LittleEndian, uint32(serial_cookie))
-	if err != nil {
-		return 0, err
-	}
-	err = binary.Write(stream, binary.LittleEndian, uint32(len(b.keys)))
-	if err != nil {
-		return 0, err
-	}
+	preambleSize := 4 + 4 + 4*len(b.keys)
+	buf := make([]byte, preambleSize+4*len(b.keys))
+	binary.LittleEndian.PutUint32(buf[0:], uint32(serial_cookie))
+	binary.LittleEndian.PutUint32(buf[4:], uint32(len(b.keys)))
+
 	for i, key := range b.keys {
-		err = binary.Write(stream, binary.LittleEndian, uint16(key))
-		if err != nil {
-			return 0, err
-		}
+		off := 8 + i*4
+		binary.LittleEndian.PutUint16(buf[off:], uint16(key))
 
 		c := b.containers[i]
-		err = binary.Write(stream, binary.LittleEndian, uint16(c.getCardinality()-1))
-		if err != nil {
-			return 0, err
-		}
+		binary.LittleEndian.PutUint16(buf[off+2:], uint16(c.getCardinality()-1))
 	}
-	startOffset := 4 + 4 + 4*len(b.keys) + 4*len(b.keys)
-	for _, c := range b.containers {
-		err = binary.Write(stream, binary.LittleEndian, uint32(startOffset))
-		if err != nil {
-			return 0, err
-		}
+
+	startOffset := preambleSize + 4*len(b.keys)
+	for i, c := range b.containers {
+		binary.LittleEndian.PutUint32(buf[preambleSize+i*4:], uint32(startOffset))
 		startOffset += getSizeInBytesFromCardinality(c.getCardinality())
 	}
+
+	_, err := stream.Write(buf)
+	if err != nil {
+		return 0, err
+	}
+
 	for _, c := range b.containers {
 		_, err := c.writeTo(stream)
 		if err != nil {


### PR DESCRIPTION
Avoid using `binary.Write` which incurs non-trivial CPU and memory overhead. Improvements are more pronounced for bitmaps with more containers. This makes the serialization code a little less friendly but seems worth it.

# Benchmarks

```
benchmark                        old ns/op     new ns/op     delta
BenchmarkSerializationSparse     2198058       350539        -84.05%
BenchmarkSerializationMid        666467        163984        -75.40%
BenchmarkSerializationDense      71531         42038         -41.23%

benchmark                        old allocs     new allocs     delta
BenchmarkSerializationSparse     18319          1528           -91.66%
BenchmarkSerializationMid        1843           155            -91.59%
BenchmarkSerializationDense      43             5              -88.37%

benchmark                        old bytes     new bytes     delta
BenchmarkSerializationSparse     445927        152896        -65.71%
BenchmarkSerializationMid        169706        140272        -17.34%
BenchmarkSerializationDense      25400         24720         -2.68%
```