### PR TITLE
methods to serialize and deserialize from base 64 encoded string

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -7,6 +7,7 @@ package roaring
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"strconv"
@@ -15,6 +16,25 @@ import (
 // RoaringBitmap represents a compressed bitmap where you can add integers.
 type RoaringBitmap struct {
 	highlowcontainer roaringArray
+}
+
+func (b *RoaringBitmap) ToBase64() (string, error) {
+	buf := new(bytes.Buffer)
+	_, err := b.WriteTo(buf)
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), err
+
+}
+
+func (b *RoaringBitmap) FromBase64(str string) (int, error) {
+
+	data, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return 0, err
+	}
+	buf := bytes.NewBuffer(data)
+
+	return b.ReadFrom(buf)
+
 }
 
 // Write out a serialized version of this bitmap to stream

--- a/serialization_test.go
+++ b/serialization_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestBase64(t *testing.T) {
+	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000)
+
+	bstr, _ := rb.ToBase64()
+
+	if bstr == "" {
+		t.Errorf("ToBase64 failed returned empty string")
+	}
+
+	newrb := NewRoaringBitmap()
+
+	_, err := newrb.FromBase64(bstr)
+
+	if err != nil {
+		t.Errorf("Failed reading from base64 string")
+	}
+
+	if !rb.Equals(newrb) {
+		t.Errorf("comparing the base64 to and from failed cannot retrieve serialized version")
+	}
+
+}
+
 func TestSerializationBasic(t *testing.T) {
 	rb := BitmapOf(1, 2, 3, 4, 5, 100, 1000)
 	l := int(rb.GetSerializedSizeInBytes())


### PR DESCRIPTION
Please consider the pull request for the methods  ToBase64 and FromBase64.  I have provided a test case.  I currently use the feature with a web service that stores the roaring bitmaps in a redis key value store.