### PR TITLE
Use unsafe/reflect in serialization

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -1,21 +1,9 @@
 package roaring
 
-import (
-	"encoding/binary"
-	"io"
-	"unsafe"
-)
+import "unsafe"
 
 type arrayContainer struct {
 	content []uint16
-}
-
-func (b *arrayContainer) readFrom(stream io.Reader) (int, error) {
-	err := binary.Read(stream, binary.LittleEndian, b.content)
-	if err != nil {
-		return 0, err
-	}
-	return 2 * len(b.content), nil
 }
 
 func (ac *arrayContainer) fillLeastSignificant16bits(x []uint32, i int, mask uint32) {

--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -10,17 +10,6 @@ type arrayContainer struct {
 	content []uint16
 }
 
-// writes the content (omitting the cardinality)
-func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
-	buf := make([]byte, 2*len(b.content))
-	for i, v := range b.content {
-		base := i * 2
-		buf[base] = byte(v)
-		buf[base+1] = byte(v >> 8)
-	}
-	return stream.Write(buf)
-}
-
 func (b *arrayContainer) readFrom(stream io.Reader) (int, error) {
 	err := binary.Read(stream, binary.LittleEndian, b.content)
 	if err != nil {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -1,21 +1,8 @@
 package roaring
 
-import (
-	"encoding/binary"
-	"io"
-)
-
 type bitmapContainer struct {
 	cardinality int
 	bitmap      []uint64
-}
-
-func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
-	err := binary.Read(stream, binary.LittleEndian, b.bitmap)
-	if err != nil {
-		return 0, err
-	}
-	return 8 * len(b.bitmap), nil
 }
 
 func newBitmapContainer() *bitmapContainer {

--- a/bitmapcontainer.go
+++ b/bitmapcontainer.go
@@ -10,24 +10,6 @@ type bitmapContainer struct {
 	bitmap      []uint64
 }
 
-// writes the content
-func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
-	// Write set
-	buf := make([]byte, 8*len(b.bitmap))
-	for i, v := range b.bitmap {
-		base := i * 8
-		buf[base] = byte(v)
-		buf[base+1] = byte(v >> 8)
-		buf[base+2] = byte(v >> 16)
-		buf[base+3] = byte(v >> 24)
-		buf[base+4] = byte(v >> 32)
-		buf[base+5] = byte(v >> 40)
-		buf[base+6] = byte(v >> 48)
-		buf[base+7] = byte(v >> 56)
-	}
-	return stream.Write(buf)
-}
-
 func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
 	err := binary.Read(stream, binary.LittleEndian, b.bitmap)
 	if err != nil {

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -1,0 +1,32 @@
+// +build !amd64,!386 appengine
+
+package roaring
+
+import "io"
+
+func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
+	buf := make([]byte, 2*len(b.content))
+	for i, v := range b.content {
+		base := i * 2
+		buf[base] = byte(v)
+		buf[base+1] = byte(v >> 8)
+	}
+	return stream.Write(buf)
+}
+
+func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
+	// Write set
+	buf := make([]byte, 8*len(b.bitmap))
+	for i, v := range b.bitmap {
+		base := i * 8
+		buf[base] = byte(v)
+		buf[base+1] = byte(v >> 8)
+		buf[base+2] = byte(v >> 16)
+		buf[base+3] = byte(v >> 24)
+		buf[base+4] = byte(v >> 32)
+		buf[base+5] = byte(v >> 40)
+		buf[base+6] = byte(v >> 48)
+		buf[base+7] = byte(v >> 56)
+	}
+	return stream.Write(buf)
+}

--- a/serialization_generic.go
+++ b/serialization_generic.go
@@ -2,7 +2,10 @@
 
 package roaring
 
-import "io"
+import (
+	"encoding/binary"
+	"io"
+)
 
 func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
 	buf := make([]byte, 2*len(b.content))
@@ -12,6 +15,14 @@ func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
 		buf[base+1] = byte(v >> 8)
 	}
 	return stream.Write(buf)
+}
+
+func (b *arrayContainer) readFrom(stream io.Reader) (int, error) {
+	err := binary.Read(stream, binary.LittleEndian, b.content)
+	if err != nil {
+		return 0, err
+	}
+	return 2 * len(b.content), nil
 }
 
 func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
@@ -29,4 +40,12 @@ func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
 		buf[base+7] = byte(v >> 56)
 	}
 	return stream.Write(buf)
+}
+
+func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
+	err := binary.Read(stream, binary.LittleEndian, b.bitmap)
+	if err != nil {
+		return 0, err
+	}
+	return 8 * len(b.bitmap), nil
 }

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -18,6 +18,16 @@ func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
 	return stream.Write(buf)
 }
 
+func (b *arrayContainer) readFrom(stream io.Reader) (int, error) {
+	buf := uint16SliceAsByteSlice(b.content)
+	return io.ReadFull(stream, buf)
+}
+
+func (b *bitmapContainer) readFrom(stream io.Reader) (int, error) {
+	buf := uint64SliceAsByteSlice(b.bitmap)
+	return io.ReadFull(stream, buf)
+}
+
 func uint64SliceAsByteSlice(slice []uint64) []byte {
 	// make a new slice header
 	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))

--- a/serialization_littleendian.go
+++ b/serialization_littleendian.go
@@ -1,0 +1,43 @@
+// +build 386 amd64,!appengine
+
+package roaring
+
+import (
+	"io"
+	"reflect"
+	"unsafe"
+)
+
+func (b *arrayContainer) writeTo(stream io.Writer) (int, error) {
+	buf := uint16SliceAsByteSlice(b.content)
+	return stream.Write(buf)
+}
+
+func (b *bitmapContainer) writeTo(stream io.Writer) (int, error) {
+	buf := uint64SliceAsByteSlice(b.bitmap)
+	return stream.Write(buf)
+}
+
+func uint64SliceAsByteSlice(slice []uint64) []byte {
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len *= 8
+	header.Cap *= 8
+
+	// return it
+	return *(*[]byte)(unsafe.Pointer(&header))
+}
+
+func uint16SliceAsByteSlice(slice []uint16) []byte {
+	// make a new slice header
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&slice))
+
+	// update its capacity and length
+	header.Len *= 2
+	header.Cap *= 2
+
+	// return it
+	return *(*[]byte)(unsafe.Pointer(&header))
+}


### PR DESCRIPTION
Serialized representations are just little endian byte slices, which can be obtained by referencing the data slice directly on certain platforms. 

On my machine, this results in 64%, 88%, and 90% reductions in runtime for `BenchmarkSerialization{Sparse,Mid,Dense}`:

    $ git checkout master
    Switched to branch 'master'
    Your branch is up-to-date with 'origin/master'.
    $ go test -bench BenchmarkSerialization -run -
    PASS
    BenchmarkSerializationSparse-8	    5000	    275510 ns/op
    BenchmarkSerializationMid-8   	   10000	    128213 ns/op
    BenchmarkSerializationDense-8 	  100000	     20826 ns/op
    ok  	github.com/tgruben/roaring	5.112s
    $ git checkout unsafe_serialization
    Switched to branch 'unsafe_serialization'
    $ go test -bench BenchmarkSerialization -run -
    PASS
    BenchmarkSerializationSparse-8	   20000	     97988 ns/op
    BenchmarkSerializationMid-8   	  100000	     14870 ns/op
    BenchmarkSerializationDense-8 	 1000000	      2043 ns/op
    ok  	github.com/tgruben/roaring	6.800s
