### PR TITLE
roaring: iterate over containers directly

### DIFF
--- a/roaring.go
+++ b/roaring.go
@@ -77,8 +77,7 @@ func (rb *RoaringBitmap) ToArray() []uint32 {
 // might differ slightly from the amount of bytes required for persistent storage
 func (rb *RoaringBitmap) GetSizeInBytes() uint64 {
 	size := uint64(8)
-	for i := 0; i < rb.highlowcontainer.size(); i++ {
-		c := rb.highlowcontainer.getContainerAtIndex(i)
+	for _, c := range rb.highlowcontainer.containers {
 		size += uint64(2) + uint64(c.getSizeInBytes())
 	}
 	return size
@@ -267,8 +266,8 @@ func (rb *RoaringBitmap) IsEmpty() bool {
 // GetCardinality returns the number of integers contained in the bitmap
 func (rb *RoaringBitmap) GetCardinality() uint64 {
 	size := uint64(0)
-	for i := 0; i < rb.highlowcontainer.size(); i++ {
-		size += uint64(rb.highlowcontainer.getContainerAtIndex(i).getCardinality())
+	for _, c := range rb.highlowcontainer.containers {
+		size += uint64(c.getCardinality())
 	}
 	return size
 }


### PR DESCRIPTION
Nearly a 20% speedup for GetCardinality().

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkCountRoaring-4             76.2          62.8          -17.59%
BenchmarkUnionRoaring-4             463808        449793        -3.02%
BenchmarkIntersectionBitset-4       13821         13631         -1.37%
BenchmarkUnionBitset-4              7327540       7410987       +1.14%
BenchmarkSparseIterateRoaring-4     942088        951706        +1.02%
BenchmarkSetRoaring-4               72.7          72.0          -0.96%
BenchmarkSparseContains-4           115731        114669        -0.92%
BenchmarkGetTestBitSet-4            24.9          25.1          +0.80%
BenchmarkCountBitset-4              32299         32152         -0.46%
BenchmarkIntersectionRoaring-4      2238          2230          -0.36%
BenchmarkSerializationDense-4       1491          1495          +0.27%
BenchmarkIterateBitset-4            657847        656736        -0.17%
BenchmarkSerializationSparse-4      103972        103831        -0.14%
BenchmarkSerializationMid-4         16406         16397         -0.05%
BenchmarkSparseIterateBitset-4      3118681       3117655       -0.03%
BenchmarkIterateRoaring-4           1581765       1581354       -0.03%
BenchmarkGetTestRoaring-4           138           138           +0.00%
BenchmarkSetBitset-4                27.6          27.6          +0.00%
```