### PR TITLE
Optimize equals

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -179,11 +179,17 @@ func (ac *arrayContainer) not(firstOfRange, lastOfRange int) container {
 func (ac *arrayContainer) equals(o interface{}) bool {
 	srb, ok := o.(*arrayContainer)
 	if ok {
+		// Check if the containers are the same object.
+		if ac == srb {
+			return true
+		}
+
 		if len(srb.content) != len(ac.content) {
 			return false
 		}
-		for i := 0; i < len(ac.content); i++ {
-			if ac.content[i] != srb.content[i] {
+
+		for i, v := range ac.content {
+			if v != srb.content[i] {
 				return false
 			}
 		}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -421,3 +421,39 @@ func BenchmarkSerializationDense(b *testing.B) {
 		s.WriteTo(w)
 	}
 }
+
+func BenchmarkEqualsSparse(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	t := NewRoaringBitmap()
+	sz := 100000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		n := uint32(r.Int31n(int32(sz)))
+		s.Add(n)
+		t.Add(n)
+	}
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		s.Equals(t)
+	}
+}
+
+func BenchmarkEqualsClone(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 100000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		s.Add(uint32(r.Int31n(int32(sz))))
+	}
+	t := s.Clone()
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		s.Equals(t)
+	}
+}

--- a/roaringarray.go
+++ b/roaringarray.go
@@ -272,8 +272,14 @@ func (ra *roaringArray) equals(o interface{}) bool {
 		if srb.size() != ra.size() {
 			return false
 		}
-		for i := 0; i < srb.size(); i++ {
-			if ra.keys[i] != srb.keys[i] || !ra.containers[i].equals(srb.containers[i]) {
+		for i, k := range ra.keys {
+			if k != srb.keys[i] {
+				return false
+			}
+		}
+
+		for i, c := range ra.containers {
+			if !c.equals(srb.containers[i]) {
 				return false
 			}
 		}


### PR DESCRIPTION
We do a lot of equality checks in our application to avoid `Xor` (and the associated allocations) if two bitmaps are equal.


Use slightly faster looping constructs for a ~20% speed up in the
normal case. Also, compare container identity to greatly speed up
comparison of cloned bitmaps.

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkEqualsClone-4      148228        17037         -88.51%
BenchmarkEqualsSparse-4     166294        133839        -19.52%
```