### PR TITLE
Speed up sequential Adds (for sparse bitmaps)

### DIFF
--- a/arraycontainer.go
+++ b/arraycontainer.go
@@ -205,7 +205,15 @@ func (ac *arrayContainer) toBitmapContainer() *bitmapContainer {
 
 }
 func (ac *arrayContainer) add(x uint16) container {
+	// Special case adding to the end of the container.
+	l := len(ac.content)
+	if l > 0 && l < arrayDefaultMaxSize && ac.content[l-1] < x {
+		ac.content = append(ac.content, x)
+		return ac
+	}
+
 	loc := binarySearch(ac.content, x)
+
 	if loc < 0 {
 		if len(ac.content) >= arrayDefaultMaxSize {
 			a := ac.toBitmapContainer()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -457,3 +457,12 @@ func BenchmarkEqualsClone(b *testing.B) {
 		s.Equals(t)
 	}
 }
+
+func BenchmarkSequentialAdd(b *testing.B) {
+	for j := 0; j < b.N; j++ {
+		s := NewRoaringBitmap()
+		for i := 0; i < 10000000; i += 16 {
+			s.Add(uint32(i))
+		}
+	}
+}

--- a/roaring.go
+++ b/roaring.go
@@ -185,7 +185,7 @@ func (rb *RoaringBitmap) Equals(o interface{}) bool {
 // Add the integer x to the bitmap
 func (rb *RoaringBitmap) Add(x uint32) {
 	hb := highbits(x)
-	ra := rb.highlowcontainer
+	ra := &rb.highlowcontainer
 	i := ra.getIndex(hb)
 	if i >= 0 {
 		var c container


### PR DESCRIPTION
We almost always build bitmaps sequentially and I imagine that's not uncommon. This adds a special case to `(*arrayContainer).add()` which just does a simple append if the value is larger than all others in the container.

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkSequentialAdd-4            38711199      16057751      -58.52%
```

Doesn't seem to hurt random add performance:

```
BenchmarkSetRoaring-4               71.4          70.5          -1.26%
```