### PR TITLE
Partial in place Xor

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -466,3 +466,47 @@ func BenchmarkSequentialAdd(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkXor(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 100000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		n := uint32(r.Int31n(int32(sz)))
+		s.Add(n)
+	}
+	x2 := NewRoaringBitmap()
+	for i := 0; i < initsize; i++ {
+		n := uint32(r.Int31n(int32(sz)))
+		x2.Add(n)
+	}
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		s.Clone().Xor(x2)
+	}
+}
+
+func BenchmarkXorLopsided(b *testing.B) {
+	b.StopTimer()
+	r := rand.New(rand.NewSource(0))
+	s := NewRoaringBitmap()
+	sz := 100000000
+	initsize := 65000
+	for i := 0; i < initsize; i++ {
+		n := uint32(r.Int31n(int32(sz)))
+		s.Add(n)
+	}
+	x2 := NewRoaringBitmap()
+	for i := 0; i < 32; i++ {
+		n := uint32(r.Int31n(int32(sz)))
+		x2.Add(n)
+	}
+	b.StartTimer()
+
+	for j := 0; j < b.N; j++ {
+		s.Clone().Xor(x2)
+	}
+}


### PR DESCRIPTION
This still builds a new container if there is a container for a given key in both bitmaps. However it is much faster if the second bitmap is much sparser than the first and slightly faster for two random bitmaps with the same cardinality and range.

Fulfills part of #27.

### Benchmark

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkXorLopsided-4              441580        38068         -91.38%
BenchmarkXor-4                      1319948       1204654       -8.73%


benchmark                  old allocs     new allocs     delta
BenchmarkXorLopsided-4     3084           71             -97.70%
BenchmarkXor-4             3084           3059           -0.81%

benchmark                   old bytes     new bytes     delta
BenchmarkXorLopsided-4      313552        36512         -88.36%
BenchmarkXor-4              443680        351968        -20.67%
```